### PR TITLE
KRACOEUS-8905:still return errors if printing xml

### DIFF
--- a/coeus-s2sgen-impl/src/main/java/org/kuali/coeus/s2sgen/impl/print/FormPrintServiceImpl.java
+++ b/coeus-s2sgen-impl/src/main/java/org/kuali/coeus/s2sgen/impl/print/FormPrintServiceImpl.java
@@ -134,8 +134,9 @@ public class FormPrintServiceImpl implements FormPrintService {
             pResult = getPDFStream(pdDocContract);
 		}
 	    if(pdDocContract.getDevelopmentProposal().getGrantsGovSelectFlag()){
-		
-		return null;
+            FormPrintResult result = new FormPrintResult();
+            result.setErrors(pResult.errors);
+            return result;
 	    }
         S2SFile attachmentDataSource = s2SPrintingService
         	.print(pResult.printables);


### PR DESCRIPTION
when an s2s form is flagged to be printed as xml no errors are returning to the controller.  Previously, the errors were added to the message map in the FormPrintServiceImpl, with recent refactoring this no longer occurs.  So we need to return the errors so we can stop processing when errors are detected.